### PR TITLE
Support detection of ICCC as a reader

### DIFF
--- a/ACIO.cpp
+++ b/ACIO.cpp
@@ -445,6 +445,9 @@ reader_type_t ACIO::getReaderType( HANDLE hSerial, unsigned int id )
 		if (strcmp(code, "ICCB") == 0) {
 			return TYPE_READER;
 		}
+		if (strcmp(code, "ICCC") == 0) {
+		  return TYPE_READER;
+		}
 		if (strcmp(code, "HBHI") == 0) {
 			return TYPE_DISPENSER;
 		}


### PR DESCRIPTION
Some cabinets have ICCC for their card reader instead of ICCA or ICCB.

This PR adds detection of ICCC as a reader instead of `TYPE_UNKNOWN`.